### PR TITLE
Match the order of jsDataArray to the order of newResponse.data.

### DIFF
--- a/src/JsonApiSerializer.ts
+++ b/src/JsonApiSerializer.ts
@@ -751,17 +751,11 @@ export class JsonApiHelper {
         // This is an array of top level objects with child, object references and included objects
         var jsDataArray = [];
         if (data) {
-            for (var dataType in data) {
-
-                if (data[dataType]) {
-                    for (var dataId in data[dataType]) {
-
-                        if (data[dataType][dataId]) {
-                            jsDataArray.push(data[dataType][dataId]);
-                        }
-                    }
+            DSUTILS.forEach(newResponse.data, (item: JsonApi.JsonApiData) => {
+                if (data[item.type] && data[item.type][item.id]) {
+                    jsDataArray.push(data[item.type][item.id]);
                 }
-            }
+            });
         }
 
         return new DeSerializeResult(jsDataArray, newResponse);


### PR DESCRIPTION
In karma/phantomjs, the order of additions to the data[dataType] hash is preserved when looping via for (var ... in). In chrome, the order does not appear to be preserved. In a debugger placed on [L:586](https://github.com/BlairAllegroTech/js-data-jsonapi/blob/js-data-jsonapi/src/JsonApiSerializer.ts#L586), immediately after data[dataType] is populated, chrome shows the hash entries ordered ascending by their key value (i.e. by id ascending). This commit copies data into the jsDataArray based on the order it was presented in the newResponse.data array. All the existing tests pass. I tried to write an additional test, but this doesn't happen in phantomjs, only in chrome :/ I'm new to testing in JS, so let me know if there's a way I could add coverage to this PR. Thanks!
